### PR TITLE
Error handling + fixes

### DIFF
--- a/chain.js
+++ b/chain.js
@@ -14,8 +14,11 @@ Chain.prototype.run = function() {
 
   var self = this;
   this.easyamqp.connection(function(conn) {
-    var call = self.callQueue.shift(),
-        method = call[0],
+    var call = self.callQueue.shift();
+    if(!call) {
+      return;
+    }
+    var method = call[0],
         args = call[1];
 
     switch(method) {

--- a/chain.js
+++ b/chain.js
@@ -20,7 +20,7 @@ Chain.prototype.run = function() {
 
     switch(method) {
       case "queue":
-        args[1] = {};
+        args[1] = args[1] || {};
         args[2] = function(queue) {
           self.lastQueue = self.lastQueueOrExchange = queue;
           self.run();

--- a/easyamqp.js
+++ b/easyamqp.js
@@ -1,7 +1,11 @@
 var amqp = require('amqp'),
-    Chain = require('./chain');
+    Chain = require('./chain'),
+    events = require('events'),
+    util = require('util');
 
 var easyamqp = module.exports = function(options, implOptions) {
+  events.EventEmitter.call(this);
+
   if(typeof(options) === "string") {
     options = { url : options };
   }
@@ -10,12 +14,20 @@ var easyamqp = module.exports = function(options, implOptions) {
   return this;
 }
 
+util.inherits(easyamqp, events.EventEmitter);
+
 easyamqp.prototype.connection = function(readyCallback) {
   if(!this.conn) {
     var self = this;
     this.conn = amqp.createConnection(this.options, this.implOptions);
     this.conn.on('ready', function() {
       self.ready = true;
+    });
+    this.conn.on('error', function(err) {
+      if(self.listeners('error').length == 0) {
+        throw err;
+      }
+      self.emit('error', err);
     });
   }
 
@@ -42,3 +54,5 @@ easyamqp.prototype.end = function() {
     return new Chain(this, method, arguments);
   }
 });
+
+

--- a/index.js
+++ b/index.js
@@ -1,7 +1,10 @@
 var easyamqp = require('./easyamqp');
 
-module.exports = {
-  createConnection : function(options, implOptions) {
-    return new easyamqp(options);
-  }
+
+module.exports = function(options, implOptions) {
+  return new easyamqp(options, implOptions);
 }
+
+module.exports.createConnection = function(options, implOptions) {
+  return new easyamqp(options, implOptions);
+};


### PR DESCRIPTION
- easyamqp extends EventEmitter and emit error message from amqp connection
- unless "on" handler is registered error thrown
- queue options were overriden by {}
- more friendly initialization, backward compatible

coffeescript example:

``` coffee
easyamqp = require 'easy-amqp'
amqp = easyamqp "amqp://..."
amqp.on 'error', (err) ->
  console.log err

amqp.queue('qname', {durable: 10, autoDelete: no})
.subscribe {ack: true}, (message, headers, deliveryInfo, m) ->
```
